### PR TITLE
Fix / Skills for new projects appear before refresh

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,7 +27,6 @@ function App() {
 
   const addProject = ({ name = "" }) => {
     const newProject = { name, userId, datePracticed: Date.now() };
-    console.log(newProject);
     axios
       .post(`https://zlld6v728l.execute-api.eu-west-2.amazonaws.com/dev/projects`, newProject)
       .then(({ data: { projects: resProject = [] } = {} }) => {
@@ -39,14 +38,13 @@ function App() {
   };
   const addSkill = (projectId, skillName) => {
     const newSkill = { name: skillName, projectId: projectId };
-    console.log(newSkill);
     axios
       .post(`https://zlld6v728l.execute-api.eu-west-2.amazonaws.com/dev/skills`, newSkill)
       .then((response) => {
         const updatedProjects = projects.map((project) => {
           const { skills = [] } = project;
           if (project.projectId === projectId) {
-            if (project.skills.length === 0) {
+            if (!project.skills) {
               return { ...project, skillToDo: response.data.skill.skillId, skills: [response.data.skill, ...skills] };
             }
             return { ...project, skills: [response.data.skill, ...skills] };


### PR DESCRIPTION
New projects were not displaying skills without a refresh. This was due to trying to find length of skills which did not exist. Fixed by instead checking for (!project.skills)